### PR TITLE
fix: panic on unwrap

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -50,7 +50,7 @@ fn main() -> Result<()> {
         .add_directive(format!("hostwatch={}", level).parse()?);
     tracing_subscriber::registry().with(filter).with(stdout_layer).with(syslog_layer_opt).init();
 
-    if !args.interface.contains(&"any".to_string()) && !args.filename.clone().unwrap().is_empty() {
+    if !args.interface.contains(&"any".to_string()) && !args.filename.clone().unwrap_or("".to_string()).is_empty() {
         panic!("File [-F] and interface [-i] modes can not be combined");
     }
     info!("Starting hostwatch on interface: {:?}", args.interface);


### PR DESCRIPTION
fixes panic mentioned in https://github.com/opnsense/hostwatch/issues/13#issuecomment-3766771727

```
thread 'main' (100472) panicked at src/main.rs:53:79:
called `Option::unwrap()` on a `None` value
```

----

Additionally I would like to point out that using `panic!` for valid error messages is IMO not a good idea. The following example is not the only occurrence of a `panic!` for a valid error/info message.

e.g.

```
panic!("File [-F] and interface [-i] modes can not be combined");
```

should be replaced with something like

```
println!("File [-F] and interface [-i] modes can not be combined");
std::process::exit(1);
```

Or a function/macro can be used that takes a string (error message) and an integer (exit code).
Depending on whether you want make use of the tracing crate you are already using anyway, the `error!` macro can be used instead of `println!`.

----

While we are at it, I have a few more suggestions (and I can create PRs for them):

- run `cargo +stable fmt --all --` to fix formatting issues
- run `cargo +stable clippy` to show all warnings and fix them
- add a gh workflow that runs at least `clippy` and `fmt`

The project should also include tests. While tests can be added over time, I think that tests should be part of a Rust project (or any project for that matter). Then running `cargo test` via a CI is a breeze to setup.