### PR TITLE
fix(clippy): implement clippy suggestions

### DIFF
--- a/src/database.rs
+++ b/src/database.rs
@@ -46,6 +46,12 @@ impl HostInfo {
     }
 }
 
+impl Default for HostInfo {
+    fn default() -> Self {
+         Self::new()
+    }
+}
+
 #[derive(Debug, Deserialize)]
 pub struct OUI {
     #[serde(rename = "Assignment")]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -146,12 +146,14 @@ impl HostWatch {
 
         if self.filename.is_some() {
             info!("Initializing packet capture on file: {:?}", self.filename.clone().unwrap());
+            #[allow(clippy::single_match)]
             match self.initialize_file_captures() {
                 Ok(_) => {}
                 Err(_) => {}
             }
         } else {
             info!("Initializing packet capture on interfaces: {:?}", self.interfaces);
+            #[allow(clippy::single_match)]
             match self.initialize_device_captures() {
                 Ok(_) => {}
                 Err(_) => {}
@@ -259,12 +261,12 @@ impl HostWatch {
                     }
                     self.device_captures.push(capture);
                     self.system_interfaces.push(device.name.clone());
-                    info!("Added capture for device: {} ({})", 
-                          device.name, 
+                    info!("Added capture for device: {} ({})",
+                          device.name,
                           device.desc.as_deref().unwrap_or("No description"));
                 } else {
                     info!("Skip capture for device: {}", device.name);
-                }    
+                }
             }
         }
         if self.device_captures.is_empty() {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -173,7 +173,7 @@ impl HostWatch {
                 Self::capture_packets(capture, interface_name, tx_clone)
             });
         }
-        for (_i, capture) in self.file_captures.drain(..).enumerate() {
+        for capture in self.file_captures.drain(..) {
             let tx_clone = tx.clone();
             thread::spawn(move || {
                 Self::capture_packets(capture, "pcap".to_string(), tx_clone)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -335,7 +335,7 @@ impl HostWatch {
                             }
                         }
                     }
-                    if !host_info.ip_address.is_none() {
+                    if host_info.ip_address.is_some() {
                         tx.send(host_info).unwrap();
                     }
                 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -33,7 +33,7 @@ fn main() -> Result<()> {
     };
 
     let syslog_layer_opt = if args.syslog {
-        let identity = std::ffi::CStr::from_bytes_with_nul(b"hostwatch\0")?;
+        let identity = c"hostwatch";
         let (options, facility) = Default::default();
         let syslog = Syslog::new(identity, options, facility).unwrap();
         Some(tracing_subscriber::fmt::layer()


### PR DESCRIPTION
This PR contains multiple commits with detailed commit messages.
I have done so to make the review easier. Feel free to squash them upon merge.

The warnings show up when running `cargo clippy`. It is always a good idea to fix those in a Rust project or define exceptions with an `#[allow(clippy::XXXXXX)]` directive.

I've added this check to a CI workflow in a separate PR.