### PR TITLE
Don't enable rusqlite bundled feature unconditionally

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2021"
 
 [dependencies]
 pcap = "2.4.0"
-rusqlite = { version = "0.39", features = ["bundled"] }
+rusqlite = { version = "0.39" }
 anyhow = "1.0"
 clap = { version = "4.0", features = ["derive"] }
 serde = { version = "1.0", features = ["derive"] }


### PR DESCRIPTION
Looks like this was accidentally re-enabled in https://github.com/opnsense/hostwatch/commit/6262efe5da92e12b7b0bb8ecf54635ac92c26fc1 